### PR TITLE
Fix SAKs expostas e url TMS Integration

### DIFF
--- a/SimpleWpfApp/Stone.config
+++ b/SimpleWpfApp/Stone.config
@@ -7,11 +7,7 @@
   
   <!-- Terminal Management Service URIs -->
   <add key="ProductionTmsUri" value="https://tms.stone.com.br" />
-  <add key="TestingTmsUri" value="https://tms-staging.stone.com.br/" />
+  <add key="TestingTmsUri" value="https://tms-integration.stone.com.br/" />
   <add key="CertificationTmsUri" value="https://tms-dev.stone.com.br" />
   
-  <!-- Sale Affiliation Keys -->
-  <add key="ProductionSak" value="DE756D68F20B4242BEC8F94B5ABCB448" />
-  <add key="TestingSak" value="" />
-  <add key="CertificationSak" value="8E51DE32849943389B67EC5E8AD7C721" />
 </configuration>


### PR DESCRIPTION
Excluí as SAKs que estavam expostas aqui no arquivo. O parceiro não precisa de SAK para operar. Só o Stonecode já resolve.
Alterei a url do TMS de "https://tms-staging.stone.com.br" para "https://tms-integration.stone.com.br".